### PR TITLE
Add simple drink water example

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,5 @@ endpoints.
 
 See `./postman` for a Postman collection. There are a few variables to set for
 the collection, so take a minute to review.
+
+The stand-alone `CPG - PlanDefinition drink water $apply` example is recommended to get started with.

--- a/packages/cpg-execution/test/fixtures/ExampleIG/input/cql/applicability-logic.cql
+++ b/packages/cpg-execution/test/fixtures/ExampleIG/input/cql/applicability-logic.cql
@@ -7,7 +7,7 @@ codesystem "SNOMED": 'http://snomed.info/sct'
 code "Dehydration Code": '34095006' from "SNOMED"
 
 // You can also make a valueset...
-// valueset "Dehydration Codes": 'http://cacnonical/ValueSet'
+// valueset "Dehydration Codes": 'http://canonical/ValueSet'
 
 context Patient
 

--- a/packages/cpg-execution/test/fixtures/ExampleIG/input/cql/applicability-logic.cql
+++ b/packages/cpg-execution/test/fixtures/ExampleIG/input/cql/applicability-logic.cql
@@ -1,0 +1,15 @@
+library ApplicabilityLogic version '0.1.0'
+
+using FHIR version '4.0.1'
+include FHIRHelpers version '4.0.1'
+
+codesystem "SNOMED": 'http://snomed.info/sct'
+code "Dehydration Code": '34095006' from "SNOMED"
+
+// You can also make a valueset...
+// valueset "Dehydration Codes": 'http://cacnonical/ValueSet'
+
+context Patient
+
+define "should have a glass of water":
+  exists([Observation: "Dehydration Code"])

--- a/packages/cpg-execution/test/fixtures/ExampleIG/input/fsh/simple-example.fsh
+++ b/packages/cpg-execution/test/fixtures/ExampleIG/input/fsh/simple-example.fsh
@@ -1,0 +1,53 @@
+Instance: ApplicabilityLogic
+InstanceOf: Library
+* status = #draft
+* type = http://terminology.hl7.org/CodeSystem/library-type#logic-library
+* content.id = "ig-loader-applicability-logic.cql"
+
+Instance: DrinkWaterRecommendation
+InstanceOf: PlanDefinition
+Usage: #definition
+Title: "Simple Plan Definition"
+Description: "Simple PlanDefinition to create a MedicationRequest to drink water if an Observation of 'thirsty' is found"
+* library = Canonical(ApplicabilityLogic)
+* status = #draft
+* action[+]
+  * textEquivalent = """
+Recommend ordering water if patient is dehydrated
+"""
+  * condition
+    * kind = #applicability
+    * expression
+      * language = #text/cql-identifier
+      * expression = "should have a glass of water"
+  * definitionCanonical = Canonical(OrderWaterActivity)
+
+Instance: OrderWaterActivity
+InstanceOf: ActivityDefinition
+Usage: #definition
+* status = #draft
+* kind = #MedicationRequest
+* productCodeableConcept = http://snomed.info/sct#11713004
+
+Instance: Patient1
+InstanceOf: Patient
+Usage: #example
+* name
+  * given = "Smith"
+
+Instance: Observation1Patient1
+InstanceOf: Observation
+* status = #final
+* subject = Reference(Patient1)
+* code = http://snomed.info/sct#34095006
+
+Instance: ExampleBundle
+InstanceOf: Bundle
+Usage: #example
+Title: "ExampleBundle"
+Description: "Example bundle with Observation and Patient inside"
+* type = #collection
+* entry[+]
+  * resource = Patient1
+* entry[+]
+  * resource = Observation1Patient1

--- a/postman/postman_collection.json
+++ b/postman/postman_collection.json
@@ -1,9 +1,9 @@
 {
 	"info": {
-		"_postman_id": "82cb449c-7979-4e84-b383-ad28d88e8540",
+		"_postman_id": "0a2a91dc-a034-4548-b06f-db5fa28089f4",
 		"name": "Reasoning Framework",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "8381182"
+		"_exporter_id": "317818"
 	},
 	"item": [
 		{
@@ -170,6 +170,53 @@
 				"body": {
 					"mode": "raw",
 					"raw": "{\n    \"resourceType\": \"Parameters\",\n    \"parameter\": [\n        {\n            \"name\": \"subject\",\n            \"valueReference\": \"Patient/{{patient}}\"\n        },\n        {\n            \"name\": \"practitioner\",\n            \"valueReference\": \"Practitioner/{{practitioner}}\"\n        },\n        {\n            \"name\": \"encounter\",\n            \"valueReference\": \"Encounter/{{encounter}}\"\n        },\n        {\n            \"name\": \"planDefinition\",\n            \"resource\": {{planDefinitionContent}}\n        },\n        {\n            \"name\": \"contentEndpoint\",\n            \"resource\": {\n                \"resourceType\": \"Endpoint\",\n                \"address\": \"{{contentEndpointAddress}}\",\n                \"status\": \"active\",\n                \"payloadType\": [\n                    {\n                        \"coding\": [\n                            {\n                                \"code\": \"content\"\n                            }\n                        ]\n                    }\n                ],\n                \"connectionType\": {\n                    \"code\": \"{{contentEndpointType}}\"\n                }\n            }\n        },\n        {\n            \"name\": \"terminologyEndpoint\",\n            \"resource\": {\n                \"resourceType\": \"Endpoint\",\n                \"address\": \"{{terminologyEndpointAddress}}\",\n                \"status\": \"active\",\n                \"payloadType\": [\n                    {\n                        \"coding\": [\n                            {\n                                \"code\": \"terminology\"\n                            }\n                        ]\n                    }\n                ],\n                \"connectionType\": {\n                    \"code\": \"{{terminologyEndpointType}}\"\n                }\n            }\n        },\n        {\n            \"name\": \"dataEndpoint\",\n            \"resource\": {\n                \"resourceType\": \"Endpoint\",\n                \"address\": \"{{dataEndpointAddress}}\",\n                \"status\": \"active\",\n                \"payloadType\": [\n                    {\n                        \"coding\": [\n                            {\n                                \"code\": \"data\"\n                            }\n                        ]\n                    }\n                ],\n                \"connectionType\": {\n                    \"code\": \"{{dataEndpointType}}\"\n                }\n            }\n        }\n    ]\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{server}}/PlanDefinition/$apply",
+					"host": [
+						"{{server}}"
+					],
+					"path": [
+						"PlanDefinition",
+						"$apply"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "CPG - PlanDefinition drink water $apply",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							""
+						],
+						"type": "text/javascript"
+					}
+				},
+				{
+					"listen": "prerequest",
+					"script": {
+						"exec": [
+							""
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"resourceType\": \"Parameters\",\n    \"parameter\": [\n        {\n            \"name\": \"url\",\n            \"valueString\": \"http://example.org/PlanDefinition/DrinkWaterRecommendation\"\n        },\n        {\n            \"name\": \"data\",\n            \"resource\": {\n                \"resourceType\": \"Bundle\",\n                \"id\": \"ExampleBundle\",\n                \"type\": \"collection\",\n                \"entry\": [\n                    {\n                        \"resource\": {\n                            \"resourceType\": \"Patient\",\n                            \"id\": \"Patient1\",\n                            \"name\": [\n                                {\n                                    \"given\": [\n                                        \"Smith\"\n                                    ]\n                                }\n                            ]\n                        }\n                    },\n                    {\n                        \"resource\": {\n                            \"resourceType\": \"Observation\",\n                            \"id\": \"Observation1Patient1\",\n                            \"status\": \"final\",\n                            \"subject\": {\n                                \"reference\": \"Patient/Patient1\"\n                            },\n                            \"code\": {\n                                \"coding\": [\n                                    {\n                                        \"code\": \"34095006\",\n                                        \"system\": \"http://snomed.info/sct\"\n                                    }\n                                ]\n                            }\n                        }\n                    }\n                ]\n            }\n        }\n    ]\n}",
 					"options": {
 						"raw": {
 							"language": "json"


### PR DESCRIPTION
While the PlanDefinition in the current collection [doesn't work](https://github.com/reason-healthcare/reason-framework/issues/4), I added a simpler example for folks to get started with.