### PR TITLE
Feature testing

### DIFF
--- a/packages/cpg-execution/src/applyPlanDefinition.ts
+++ b/packages/cpg-execution/src/applyPlanDefinition.ts
@@ -191,21 +191,22 @@ export const applyPlanDefinition = async (
     }
     const libraries = libraryResults.filter(is.Library)
 
-    const actionBundles = await Promise.all(
-      planDefinition.action.map(
-        async (action) =>
-          await applyPlanDefinitionAction(
-            action,
-            planDefinition,
-            args,
-            contentResolver,
-            terminologyResolver,
-            dataResolver,
-            resourceBundle,
-            libraries
-          )
+    // Use for loop instead of .map so that actions are processed asynchronously. Otherwise request groups will be assigned to the incorrect actions
+    let actionBundles = []
+    for (const action of planDefinition.action) {
+      const result = await applyPlanDefinitionAction(
+        action,
+        planDefinition,
+        args,
+        contentResolver,
+        terminologyResolver,
+        dataResolver,
+        resourceBundle,
+        libraries
       )
-    )
+      actionBundles.push(result)
+    }
+
     if (actionBundles != null) {
       requestGroup.action = actionBundles.map((a) => a?.action).filter(notEmpty)
     }

--- a/packages/cpg-execution/src/applyPlanDefinitionAction.ts
+++ b/packages/cpg-execution/src/applyPlanDefinitionAction.ts
@@ -257,7 +257,6 @@ export const applyPlanDefinitionAction = async (
 
   // DefinitionCanonical...
   if (definitionCanonical != null) {
-
     const definitionResource = await contentResolver.resolveCanonical(
       definitionCanonical,
       ['ActivityDefinition', 'PlanDefinition', 'Questionnaire']
@@ -331,7 +330,6 @@ export const applyPlanDefinitionAction = async (
           ) //callback fn to declare types? Otherwise erroring bc of type 'undefined'
       }
     } else if (is.PlanDefinition(definitionResource)) {
-
       const planDefinitionArgs: ApplyPlanDefinitionArgs = {
         ...args,
         planDefinition: definitionResource
@@ -380,7 +378,7 @@ export const applyPlanDefinitionAction = async (
 
   // Process any children...
   if (!isAtomic(action) && action.action != null) {
-   // Use for loop instead of .map so that actions are processed asynchronously. Otherwise request groups will be assigned to the incorrect actions
+    // Use for loop instead of .map so that actions are processed asynchronously. Otherwise request groups will be assigned to the incorrect actions
     const childActionBundlesRaw = []
     for (const childAction of action.action) {
       const result = await applyPlanDefinitionAction(

--- a/packages/cpg-execution/src/expression.ts
+++ b/packages/cpg-execution/src/expression.ts
@@ -95,10 +95,6 @@ export const processDynamicValue = async (
           expression
         )}`
       )
-      console.log(
-        JSON.stringify(targetResource) +
-          'targetResource from processDynamicValue function'
-      )
       return targetResource
     }
 

--- a/packages/cpg-test-support/TODO.md
+++ b/packages/cpg-test-support/TODO.md
@@ -3,3 +3,10 @@
 1. Documentation
 2. Refactor assertions for readability and performance
 3. Github CI action
+4. Use human readable identifiers - maybe title?
+5. Improve error handling for selection behavior
+
+  Current: Selection behaviors on actions are optional. Selection behavior is hybrid of titles/definitions. Only definitions that are unused will be checked at test completion.
+
+  Option 1: separate selection behavior from reocommendations so that selection only uses action titles and definitions/requests are separate
+  Option 2: only test selection behaviors that point to definitions/requests

--- a/packages/cpg-test-support/step_definitions/steps.ts
+++ b/packages/cpg-test-support/step_definitions/steps.ts
@@ -54,7 +54,7 @@ Given(
 
 When(
   'apply is called with context {string}',
-  {timeout: 3 * 5000},
+  { timeout: 3 * 5000 },
   async function (this: TestContext, patientContextIdentifier: string) {
     this.patientContextIdentifier = patientContextIdentifier
     const reference = `Bundle/${patientContextIdentifier}`
@@ -177,7 +177,9 @@ Then(
       }
     }
 
-    const findSelectionGroup = (action: fhir4.RequestGroupAction[]): boolean => {
+    const findSelectionGroup = (
+      action: fhir4.RequestGroupAction[]
+    ): boolean => {
       let isMatch = false
       for (let i = 0; i < action.length && !isMatch; i++) {
         let subAction = action[i]
@@ -206,18 +208,20 @@ Then(
             ? getInstantiatesCanonical(resource)
             : undefined
           return canonical ? canonical.split('/').pop() : null
-        })  // this is the response from server
+        })
         .filter(notEmpty)
       isMatch =
         selectionGroupActivityIds.sort().toString() ===
         activityDefinitionIdentifiers.sort().toString()
       if (selectionGroupActivityIds.length == 0) {
         const selectionGroupTitles = selectionGroupAction
-        .map((subAction) => {
-          return subAction.title
-        })  // this is the response from server
-        .filter(notEmpty)
-        isMatch = selectionGroupTitles.sort().toString() === activityDefinitionIdentifiers.sort().toString()
+          .map((subAction) => {
+            return subAction.title
+          })
+          .filter(notEmpty)
+        isMatch =
+          selectionGroupTitles.sort().toString() ===
+          activityDefinitionIdentifiers.sort().toString()
       }
       if (isMatch) {
         selectionGroupActivityIds.forEach(
@@ -233,30 +237,24 @@ Then(
 
     let isMatch = false
     if (this.cpgResponse?.entry) {
-      for (
-        let i = 0;
-        i < this.cpgResponse.entry.length && !isMatch;
-        i++
-      ) {
+      for (let i = 0; i < this.cpgResponse.entry.length && !isMatch; i++) {
         const resource = this.cpgResponse.entry[i]
           .resource as fhir4.RequestGroup
-        isMatch = resource.action
-          ? findSelectionGroup(resource.action)
-          : false
+        isMatch = resource.action ? findSelectionGroup(resource.action) : false
       }
     }
 
     const message =
-    // !isSelectionMatch
-    //   ? `Recommendation with selection behavior "${selectionBehaviorCode}" expected, but does not exist`
-    //   :
+      // !isSelectionMatch
+      //   ? `Recommendation with selection behavior "${selectionBehaviorCode}" expected, but does not exist`
+      //   :
       `\nExpected recommendations:\n- ${activityDefinitionIdentifiers.join(
-          '\n- '
-        )} \nBut found:\n- ${
-          isEmpty(this.requestResources)
-            ? 'no recommendations'
-            : this.requestResources?.join('\n- ')
-        }`
+        '\n- '
+      )} \nBut found:\n- ${
+        isEmpty(this.requestResources)
+          ? 'no recommendations'
+          : this.requestResources?.join('\n- ')
+      }`
     assert(isMatch, message)
   }
 )

--- a/packages/cpg-test-support/step_definitions/steps.ts
+++ b/packages/cpg-test-support/step_definitions/steps.ts
@@ -203,11 +203,19 @@ Then(
             ? getInstantiatesCanonical(resource)
             : undefined
           return canonical ? canonical.split('/').pop() : null
-        })
+        })  // this is the response from server
         .filter(notEmpty)
       isMatch =
         selectionGroupActivityIds.sort().toString() ===
         activityDefinitionIdentifiers.sort().toString()
+      if (selectionGroupActivityIds.length == 0) {
+        const selectionGroupTitles = selectionGroupAction
+        .map((subAction) => {
+          return subAction.title
+        })  // this is the response from server
+        .filter(notEmpty)
+        isMatch = selectionGroupTitles.sort().toString() === activityDefinitionIdentifiers.sort().toString()
+      }
       if (isMatch) {
         selectionGroupActivityIds.forEach(
           (id) =>

--- a/packages/cpg-test-support/step_definitions/steps.ts
+++ b/packages/cpg-test-support/step_definitions/steps.ts
@@ -54,6 +54,7 @@ Given(
 
 When(
   'apply is called with context {string}',
+  {timeout: 3 * 5000},
   async function (this: TestContext, patientContextIdentifier: string) {
     this.patientContextIdentifier = patientContextIdentifier
     const reference = `Bundle/${patientContextIdentifier}`


### PR DESCRIPTION
CPG Test Support:
- Add assertion 'select {string} of the following actions should be present' to support selection behavior on actions that do not have definitionCanonical. Instead these actions will be identified by action.title
- Improve failure messages: log selection behavior groups that were returned from $apply

CPG Execution:
- Fix bug: handle assignment of request groups to action.definitionCanonical asynchronously